### PR TITLE
Add support for an NFS server without block device

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,8 +2,9 @@
 #type of filesystem to create on disk
 nfs_fstype: "xfs"
 
-#target path to disk
-nfs_disk_location: "/dev/null"
+#block device (disk) on which to create the exported filesystem.
+#if the disk is not defined, formatting and mounting will not be done.
+nfs_disk_location:
 
 #Path to exported filesystem mountpoint on nfs servers
 nfs_export: "/srv"

--- a/tasks/nfs-server.yml
+++ b/tasks/nfs-server.yml
@@ -3,30 +3,37 @@
   yum:
     name: nfs-utils
     state: present
-- name: ensure nfs service is running
-  service:
-    name: nfs-server
-    state: started
-    enabled: yes
-- name: create filesystem on disk
-  filesystem:
-    fstype: "{{ nfs_fstype }}"
-    dev: "{{ nfs_disk_location }}"
-- name: check if exported filesystem mountpoint
+
+- name: ensure exported path exists
   file:
     path: "{{ nfs_export }}"
     state: directory
-- name: mount filesystem
-  mount:
-    path: "{{ nfs_export }}"
-    src: "{{ nfs_disk_location }}"
-    fstype: "{{ nfs_fstype }}"
-    state: mounted
+
+- block:
+  - name: create filesystem on disk
+    filesystem:
+      fstype: "{{ nfs_fstype }}"
+      dev: "{{ nfs_disk_location }}"
+  - name: mount filesystem
+    mount:
+      path: "{{ nfs_export }}"
+      src: "{{ nfs_disk_location }}"
+      fstype: "{{ nfs_fstype }}"
+      state: mounted
+  when: nfs_disk_location is not none
+
 - name: update exports file
   lineinfile:
     path: /etc/exports
     regexp: "{{ nfs_export }}"
     line: "{{ nfs_export }}   *(rw,insecure,no_root_squash)"
   notify: re-export filesystem
+
+- name: ensure nfs service is running
+  service:
+    name: nfs-server
+    state: started
+    enabled: yes
+
 - name: flush handlers
   meta: flush_handlers


### PR DESCRIPTION
Enable NFS to export a filesystem subtree, instead of an entire disk.
This is suitable for small-scale deployments, test cases, or infrastructure
that doesn't support block devices.