### PR TITLE
Allow to deploy NFS clients without an nfs_server host

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Example Playbook
           nfs_enable:
             server: "{{ inventory_hostname in groups['nfs_server'] }}"
             clients: "{{ inventory_hostname in groups['nfs_clients'] }}"
+          nfs_export: "{{ hostvars['nfs_server']['nfs_export'] }}"
 
 
 Author Information

--- a/tasks/nfs-clients.yml
+++ b/tasks/nfs-clients.yml
@@ -10,6 +10,6 @@
 - name: mount the filesystem
   mount:
     path: "{{ nfs_client_mnt_point}}"
-    src: "{{ nfs_server }}:{{ (hostvars[nfs_server] | default({'nfs_export': nfs_export}))['nfs_export'] }}"
+    src: "{{ nfs_server }}:{{ nfs_export }}"
     fstype: nfs
     state: mounted

--- a/tasks/nfs-clients.yml
+++ b/tasks/nfs-clients.yml
@@ -10,6 +10,6 @@
 - name: mount the filesystem
   mount:
     path: "{{ nfs_client_mnt_point}}"
-    src: "{{ nfs_server }}:{{ hostvars[nfs_server]['nfs_export'] }}"
+    src: "{{ nfs_server }}:{{ (hostvars[nfs_server] | default({'nfs_export': nfs_export}))['nfs_export'] }}"
     fstype: nfs
     state: mounted


### PR DESCRIPTION
If the host nfs_server is not defined, get nfs_export from variables.