### PR TITLE
Server fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,16 @@ Role Variables
 
 `nfs_disk_location` is the target path to the disk.
 
+`nfs_server_hostname` is the hostname or IP of the nfs server 
+
 `nfs_export` is the path to exported filesystem mountpoint on the nfs server.
 
 `nfs_client_mnt_point` is the path to the mountpoint on the nfs clients.
+
+Groups
+------
+
+The groups `nfs_server` and `nfs_clients` must exist.
 
 Dependencies
 ------------
@@ -38,8 +45,6 @@ Example Playbook
           nfs_enable:
             server: "{{ inventory_hostname in groups['nfs_server'] }}"
             clients: "{{ inventory_hostname in groups['nfs_clients'] }}"
-          nfs_export: "{{ hostvars['nfs_server']['nfs_export'] }}"
-
 
 Author Information
 ------------------

--- a/README.md
+++ b/README.md
@@ -16,11 +16,13 @@ Role Variables
 
 `nfs_disk_location` is the target path to the disk.
 
-`nfs_server_hostname` is the hostname or IP of the nfs server 
+`nfs_server_hostname` is the hostname or IP of the nfs server.
 
 `nfs_export` is the path to exported filesystem mountpoint on the nfs server.
 
 `nfs_client_mnt_point` is the path to the mountpoint on the nfs clients.
+
+If filesystem creation is not required then `nfs_fstype` and `nfs_disk_location` can be omitted.
 
 Groups
 ------

--- a/tasks/nfs-clients.yml
+++ b/tasks/nfs-clients.yml
@@ -7,9 +7,10 @@
   file:
     path: "{{ nfs_client_mnt_point }}"
     state: directory
+
 - name: mount the filesystem
   mount:
     path: "{{ nfs_client_mnt_point}}"
-    src: "{{ nfs_server }}:{{ nfs_export }}"
+    src: "{{ nfs_server_hostname }}:{{ nfs_export }}"
     fstype: nfs
     state: mounted


### PR DESCRIPTION
Fixes #8 for undefined `nfs_server` variable, see discussion there.

Note that the `nfs_export` variable was removed from the example play too; this was the only role variable in the example and used the `nfs_server` variable too. If we want to show variables we should show all of them but I don't think its necessary.