### PR TITLE
grow the fs using option resizefs from filesystem module

### DIFF
--- a/tasks/nfs-server.yml
+++ b/tasks/nfs-server.yml
@@ -14,18 +14,18 @@
       filesystem:
         fstype: "{{ nfs_fstype }}"
         dev: "{{ nfs_disk_location }}"
+        resizefs: true
     - name: mount filesystem
       mount:
         path: "{{ nfs_export }}"
         src: "{{ nfs_disk_location }}"
         fstype: "{{ nfs_fstype }}"
         state: mounted
-    - name: grow xfs filesystem to the maximum size
-      command: "xfs_growfs {{ nfs_export }}"
-      when: nfs_fstype == 'xfs'
-    - name: grow ext filesystem to the maximum size
-      command: "resize2fs {{ nfs_disk_location }}"
-      when: nfs_fstype == 'ext4'
+    - name: grow filesystem after mounting (xfs requires to be mounted)
+      filesystem:
+        fstype: "{{ nfs_fstype }}"
+        dev: "{{ nfs_disk_location }}"
+        resizefs: true
   when: nfs_disk_location is not none
 
 - name: update exports file


### PR DESCRIPTION
using the command module is not idempotent. the `grow filesystem` task was being executed always. Using the `resizefs` option is idempotent and supports more file sytem types
https://docs.ansible.com/ansible/2.5/modules/filesystem_module.html#parameters