### PR TITLE
Yaml lint fixes

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,14 +1,15 @@
-extends: default                   
-                                   
-rules:                             
-  indentation:                     
-    spaces: consistent             
-  braces:                          
-    max-spaces-inside: 1           
-    level: error                   
-  brackets:                        
-    max-spaces-inside: 1           
-    level: error                   
-  line-length: disable             
-  truthy: disable                  
-  comments-indentation: disable    
+---
+extends: default
+
+rules:
+  indentation:
+    spaces: consistent
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  line-length: disable
+  truthy: disable
+  comments-indentation: disable


### PR DESCRIPTION
Was failing in travis with:

```
0.20s$ yamllint .
./.yamllint
  1:1       warning  missing document start "---"  (document-start)
  1:17      error    trailing spaces  (trailing-spaces)
  2:1       error    trailing spaces  (trailing-spaces)
  3:7       error    trailing spaces  (trailing-spaces)
  4:15      error    trailing spaces  (trailing-spaces)
  5:23      error    trailing spaces  (trailing-spaces)
  6:10      error    trailing spaces  (trailing-spaces)
  7:25      error    trailing spaces  (trailing-spaces)
  8:17      error    trailing spaces  (trailing-spaces)
  9:12      error    trailing spaces  (trailing-spaces)
  10:25     error    trailing spaces  (trailing-spaces)
  11:17     error    trailing spaces  (trailing-spaces)
  12:23     error    trailing spaces  (trailing-spaces)
  13:18     error    trailing spaces  (trailing-spaces)
  14:32     error    trailing spaces  (trailing-spaces)
```