### PR TITLE
Tolerate stale nfs file handles

### DIFF
--- a/tasks/nfs-clients.yml
+++ b/tasks/nfs-clients.yml
@@ -5,8 +5,6 @@
     path: "{{ item.get('nfs_client_mnt_point', nfs_client_mnt_point) }}"
   register: _nfs_mountpoint
   failed_when: false
-- debug:
-    var: _nfs_mountpoint
 - name: unmount stale nfs mount
   mount:
     path: "{{ item.get('nfs_client_mnt_point', nfs_client_mnt_point) }}"

--- a/tasks/nfs-clients.yml
+++ b/tasks/nfs-clients.yml
@@ -1,6 +1,18 @@
 ---
 
 - name: check if mount directory exists
+  stat:
+    path: "{{ item.get('nfs_client_mnt_point', nfs_client_mnt_point) }}"
+  register: _nfs_mountpoint
+  failed_when: false
+- debug:
+    var: _nfs_mountpoint
+- name: unmount stale nfs mount
+  mount:
+    path: "{{ item.get('nfs_client_mnt_point', nfs_client_mnt_point) }}"
+    state: unmounted
+  when: "'Stale file handle' in _nfs_mountpoint.msg | default('')"
+- name: ensure mount directory exists
   file:
     path: "{{ item.get('nfs_client_mnt_point', nfs_client_mnt_point) }}"
     state: directory


### PR DESCRIPTION
Currently the https://github.com/stackhpc/ansible-role-cluster-nfs/blob/f7d60796844d6b795aa3723670a3cf3c34154c03/tasks/nfs-clients.yml#L4 task can fail if e.g. the nfs server has been rebooted while the client had a mount. This fixes that by unmounting if there is a stale file handle on the desired mount path.