### PR TITLE
Allow defining multiple clients allowed to mount an export

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Role Variables
 
 `nfs_export` is the path to exported filesystem mountpoint on the NFS server. Optional, default "/srv".
 
-`nfs_export_subnet` is the host or network to which the export is shared. Optional, "*".
+`nfs_export_clients` is the client list allowed to mount the filesystem.
+See "Machine Name Formats` in `man exports`. Optional string, default "*".
+Note that multiple clients may be specified as a space-separated string (not a yaml list).
 
 `nfs_export_options` are the options to apply to the export. Optional, default "rw,secure,root_squash".
 
@@ -44,6 +46,14 @@ None
 Example Playbook
 ----------------
 
+Assuming:
+- An inventory group `nfs_server` containing a single host
+- An inventory group `nfs_clients` containing one or more clients
+- The hostvar `ansible_host` containing hosts' IP address
+
+the example below configures a root-squashed read/write share which can only
+be mounted by the clients.
+
     ---
     - hosts:
       - nfs_server
@@ -55,7 +65,7 @@ Example Playbook
             server: "{{ inventory_hostname in groups['nfs_server'] }}"
             clients: "{{ inventory_hostname in groups['nfs_clients'] }}"
           nfs_server: "{{ hostvars['nfs_server']['ansible_host'] }}"
-
+          nfs_export_clients: "{{ groups['nfs_clients'] | map('extract', hostvars, 'ansible_host') | join(' ') }}"
 
 Author Information
 ------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,7 @@ nfs_disk_location:
 
 # Path to exported filesystem mountpoint on nfs servers
 nfs_export: "/srv"
-nfs_export_subnet: "*"
+nfs_export_clients: "*"
 nfs_export_options: "rw,secure,root_squash"
 
 # Path to mountpoint on nfs clients

--- a/tasks/nfs-server.yml
+++ b/tasks/nfs-server.yml
@@ -28,7 +28,8 @@
   lineinfile:
     path: /etc/exports
     regexp: "{{ item.get('nfs_export', nfs_export) }}"
-    line: "{{ item.get('nfs_export', nfs_export) }}   {{ item.get('nfs_export_subnet', nfs_export_subnet) }}({{ item.get('nfs_export_options', nfs_export_options) }})"
+    # uses -$OPTIONS format to set default options for all clients
+    line: "{{ item.get('nfs_export', nfs_export) }} -{{ item.get('nfs_export_options', nfs_export_options) }} {{ item.get('nfs_export_clients', nfs_export_clients) }}"
   notify: re-export filesystem
 
 - name: ensure nfs service is running


### PR DESCRIPTION
Replaces `nfs_export_subnet` with `nfs_export_clients` and provides export options as default for all clients, to allow defining multiple clients allowed to mount the export.