### PR TITLE
Mark all NFS mounts as being a network mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Note that multiple clients may be specified as a space-separated string (not a y
 
 `nfs_client_mnt_point` is the path to the mountpoint on the NFS clients. Optional, default "/mnt".
 
-`nfs_client_mnt_options` allows passing mount options to the NFS client. Optional, default "defaults,nosuid,nodev".
+`nfs_client_mnt_options` allows passing mount options to the NFS client. Optional, default "defaults,nosuid,nodev,_netdev".
 
 `nfs_client_mnt_state` desired state for the mount. As passed to the ansible `mount` 
 builtin module. Can be one of "absent", "mounted", "present", "unmounted" or 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,7 +15,7 @@ nfs_export_options: "rw,secure,root_squash"
 nfs_client_mnt_point: "/mnt"
 
 # nfs client mount options
-nfs_client_mnt_options: "defaults,nosuid,nodev"
+nfs_client_mnt_options: "defaults,nosuid,nodev,_netdev"
 
 nfs_client_mnt_state: mounted
 


### PR DESCRIPTION
From systemd manuals:
> _netdev may be added to the mount option string of the unit, which forces systemd to consider the mount unit a network mount.

Note this may not be sufficent to ensure correct ordering, depending on use, but it is always correct.